### PR TITLE
Bourne shell string comparison uses a single equal

### DIFF
--- a/download/excavator.sh
+++ b/download/excavator.sh
@@ -5,7 +5,7 @@ MD5='270b14d9a177397b58f5e6696021ed4d'
 
 case "$1" in
 verify)
-        [ -f excavator ] && [ `md5sum excavator | awk '{print $1}'` == "$MD5" ]
+        [ -f excavator ] && [ `md5sum excavator | awk '{print $1}'` = "$MD5" ]
         exit $?
         ;;
 download)


### PR DESCRIPTION
excavator.sh is a shell script responsible for downloading the Nicehash excavator binary when starting nuxhash. It tries to check to see if the binary already exists and to verify file integrity, however an incorrect Bourne shell string comparison means it fails the verify stage and re-downloads the binary every time regardless.

Bourne shell uses a single equal for string comparison, where as Bash can use one or two equals to give the same effect.

Using the double equals as it currently is gives the following error when you start nuxhash:
`nuxhash/download/excavator.sh: 8: [: 270b14d9a177397b58f5e6696021ed4d: unexpected operator`

With this change the download script can actually verify that the binary already exists and thus doesn't have to download it again.