### PR TITLE
Remove extra bracket causing syntax error

### DIFF
--- a/nuxhash/daemon.py
+++ b/nuxhash/daemon.py
@@ -216,7 +216,7 @@ def do_mining(nx_miners, nx_settings, nx_benchmarks, nx_devices):
             benchmarks = nx_benchmarks[device]
             if algorithm.name in benchmarks:
                 return sum([mbtc_per_hash[algorithm.algorithms[i]]
-                            *benchmarks[algorithm.name][i]]
+                            * benchmarks[algorithm.name][i]
                             for i in range(len(algorithm.algorithms))])
             else:
                 return 0.0


### PR DESCRIPTION
A typo was introduced in commit 1c0a14a which causes invalid syntax due to an extra bracket.

This was discovered when I attempted to install the package. I saw this error given by easy_install/setuptools:
```
byte-compiling build/bdist.linux-x86_64/egg/nuxhash/daemon.py to daemon.cpython-35.pyc
  File "build/bdist.linux-x86_64/egg/nuxhash/daemon.py", line 220
    for i in range(len(algorithm.algorithms))])
                                             ^
SyntaxError: invalid syntax
```

I also noticed that you've been making many new commits to the master branch which include some WIP things such as the new GUI and other development and testing related changes. I would strongly recommend that you create a different branch when working on these things and only merge them into the master branch once they've been fully tested and proven to work. Having syntax typos being committed to the master branch isn't good practice.