### PR TITLE
Update nhmp address. The old one is deprecated.

### DIFF
--- a/nuxhash/miners/excavator.py
+++ b/nuxhash/miners/excavator.py
@@ -30,7 +30,6 @@ ALGORITHMS = [
     'lyra2z',
     'x16r'
     ]
-NHMP_PORT = 3200
 
 
 class ExcavatorError(Exception):
@@ -135,7 +134,7 @@ class ExcavatorServer(object):
 
     def _subscribe(self):
         region, wallet, worker = self._subscription
-        self.send_command('subscribe', [f'nhmp.{region}.nicehash.com:{NHMP_PORT}',
+        self.send_command('subscribe', [f'nhmp.auto.nicehash.com:9200',
                                         f'{wallet}.{worker}:x'])
 
     def stop(self):


### PR DESCRIPTION
Commit: QuickFix. The old adresses (nhmp.region.nicehash.com) and port(3200) did not work anymore.